### PR TITLE
Codegen fixes

### DIFF
--- a/codegen.go
+++ b/codegen.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"go/format"
+	"reflect"
 	"regexp"
 	"strings"
 	"unicode"
@@ -238,7 +239,8 @@ func (codegen *CodeGenerator) writeEnumConstants(info *enumSchemaInfo, buffer *b
 
 func (codegen *CodeGenerator) writeImportStatement() error {
 	buffer := codegen.codeSnippets[0]
-	_, err := buffer.WriteString(`import "gopkg.in/avro.v0"`)
+	packageName := reflect.TypeOf(CodeGenerator{}).PkgPath()
+	_, err := buffer.WriteString(fmt.Sprintf(`import "%s"`, packageName))
 	if err != nil {
 		return err
 	}

--- a/codegen.go
+++ b/codegen.go
@@ -387,10 +387,13 @@ func (codegen *CodeGenerator) writeStructFieldType(schema Schema, buffer *bytes.
 		_, err = buffer.WriteString("[]byte")
 	case Record:
 		{
-			_, err = buffer.WriteString("*")
-			if err != nil {
-				return err
-			}
+
+			/*
+				_, err = buffer.WriteString("*")
+				if err != nil {
+					return err
+				}
+			*/
 			recordSchema := schema.(*RecordSchema)
 
 			schemaInfo, err := newRecordSchemaInfo(recordSchema)
@@ -419,14 +422,22 @@ func (codegen *CodeGenerator) writeStructFieldType(schema Schema, buffer *bytes.
 }
 
 func (codegen *CodeGenerator) writeStructUnionType(schema *UnionSchema, buffer *bytes.Buffer) error {
-	var unionType Schema
-	if schema.Types[0].Type() == Null {
-		unionType = schema.Types[1]
-	} else if len(schema.Types) == 1 || schema.Types[1].Type() == Null {
-		unionType = schema.Types[0]
+
+	if len(schema.Types) == 1 {
+		return codegen.writeStructFieldType(schema.Types[0], buffer)
 	}
 
-	if unionType != nil && codegen.isNullable(unionType) {
+	if len(schema.Types) == 2 {
+		var unionType Schema
+		if schema.Types[0].Type() == Null {
+			unionType = schema.Types[1]
+		} else if schema.Types[1].Type() == Null {
+			unionType = schema.Types[0]
+		}
+		_, err := buffer.WriteString("*")
+		if err != nil {
+			return err
+		}
 		return codegen.writeStructFieldType(unionType, buffer)
 	}
 

--- a/codegen.go
+++ b/codegen.go
@@ -238,7 +238,7 @@ func (codegen *CodeGenerator) writeEnumConstants(info *enumSchemaInfo, buffer *b
 
 func (codegen *CodeGenerator) writeImportStatement() error {
 	buffer := codegen.codeSnippets[0]
-	_, err := buffer.WriteString(`import "github.com/elodina/go-avro"`)
+	_, err := buffer.WriteString(`import "gopkg.in/avro.v0"`)
 	if err != nil {
 		return err
 	}

--- a/codegen.go
+++ b/codegen.go
@@ -388,12 +388,10 @@ func (codegen *CodeGenerator) writeStructFieldType(schema Schema, buffer *bytes.
 	case Record:
 		{
 
-			/*
-				_, err = buffer.WriteString("*")
-				if err != nil {
-					return err
-				}
-			*/
+			_, err = buffer.WriteString("*")
+			if err != nil {
+				return err
+			}
 			recordSchema := schema.(*RecordSchema)
 
 			schemaInfo, err := newRecordSchemaInfo(recordSchema)
@@ -434,9 +432,11 @@ func (codegen *CodeGenerator) writeStructUnionType(schema *UnionSchema, buffer *
 		} else if schema.Types[1].Type() == Null {
 			unionType = schema.Types[0]
 		}
-		_, err := buffer.WriteString("*")
-		if err != nil {
-			return err
+		if !codegen.isNullable(unionType) {
+			_, err := buffer.WriteString("*")
+			if err != nil {
+				return err
+			}
 		}
 		return codegen.writeStructFieldType(unionType, buffer)
 	}

--- a/codegen.go
+++ b/codegen.go
@@ -396,7 +396,7 @@ func (codegen *CodeGenerator) writeStructUnionType(schema *UnionSchema, buffer *
 	var unionType Schema
 	if schema.Types[0].Type() == Null {
 		unionType = schema.Types[1]
-	} else if schema.Types[1].Type() == Null {
+	} else if len(schema.Types) == 1 || schema.Types[1].Type() == Null {
 		unionType = schema.Types[0]
 	}
 
@@ -473,7 +473,7 @@ func (codegen *CodeGenerator) writeStructConstructorFieldValue(info *recordSchem
 		}
 	case *IntSchema:
 		{
-			defaultValue, ok := field.Default.(float64)
+			defaultValue, ok := field.Default.(int32)
 			if !ok {
 				return fmt.Errorf("Invalid default value for %s field of type %s", field.Name, field.Type.GetName())
 			}
@@ -481,7 +481,7 @@ func (codegen *CodeGenerator) writeStructConstructorFieldValue(info *recordSchem
 		}
 	case *LongSchema:
 		{
-			defaultValue, ok := field.Default.(float64)
+			defaultValue, ok := field.Default.(int64)
 			if !ok {
 				return fmt.Errorf("Invalid default value for %s field of type %s", field.Name, field.Type.GetName())
 			}

--- a/codegen_test.go
+++ b/codegen_test.go
@@ -41,7 +41,7 @@ func extractStructTypes(code string) (map[string]*ast.StructType, error) {
 	}
 
 	// Print the AST. Useful when tests fail
-	ast.Print(fset, f)
+	//ast.Print(fset, f)
 
 	structs := map[string]*ast.StructType{}
 	for _, decl := range f.Decls {
@@ -121,7 +121,7 @@ func TestCodegen(t *testing.T) {
 			}},
 			"Person": {{
 				GoName:  "Address",
-				GoType:  "*Address",
+				GoType:  "Address",
 				AvroTag: "address",
 			}},
 		},
@@ -146,19 +146,36 @@ func TestCodegen(t *testing.T) {
 			}},
 		},
 	}, {
-		name: "pointer",
+		name: "optional",
 		schema: `{
 			"type": "record",
 			"name": "Person",
 			"fields": [
-				{"name": "first_name", "type": [ "null", "string" ]}
+				{"name": "first_name", "type": [ "null", "string" ]},
+				{
+					"name": "address",
+					"type": [
+						"null",
+						{
+							"type": "record",
+							"name": "address",
+							"fields": [
+								{ "name": "suburb", "type": "string" }
+							]
+						}
+					]
+				}
 			]
 		}`,
 		expect: map[string][]structField{
 			"Person": {{
 				GoName:  "FirstName",
-				GoType:  "string",
+				GoType:  "*string",
 				AvroTag: "first_name",
+			}, {
+				GoName:  "Address",
+				GoType:  "*Address",
+				AvroTag: "address",
 			}},
 		},
 	}} {

--- a/codegen_test.go
+++ b/codegen_test.go
@@ -1,0 +1,238 @@
+package avro
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"testing"
+)
+
+func TestGoStructFieldName(t *testing.T) {
+
+	for input, expect := range map[string]string{
+		"name":       "Name",
+		"first_name": "FirstName",
+		"first-name": "FirstName",
+		"firstName":  "FirstName",
+		"fieldID":    "FieldID",
+		"field-id":   "FieldId",
+	} {
+
+		got := toGoStructFieldName(input)
+		if got != expect {
+			t.Errorf("Expected %s -> %s, got %s", input, expect, got)
+		}
+	}
+}
+
+type structField struct {
+	GoName  string
+	GoType  string
+	AvroTag string
+}
+
+func extractStructTypes(code string) (map[string]*ast.StructType, error) {
+	// Extract the struct definitions from the code
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "", code, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	// Print the AST. Useful when tests fail
+	ast.Print(fset, f)
+
+	structs := map[string]*ast.StructType{}
+	for _, decl := range f.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		if gd.Tok != token.TYPE {
+			continue
+		}
+		typeSpec, ok := gd.Specs[0].(*ast.TypeSpec)
+		if !ok {
+			continue
+		}
+
+		structType, ok := typeSpec.Type.(*ast.StructType)
+		if !ok {
+			continue
+		}
+
+		structs[typeSpec.Name.Name] = structType
+	}
+
+	return structs, nil
+}
+
+func TestCodegen(t *testing.T) {
+
+	for _, testCase := range []struct {
+		name   string
+		schema string
+		expect map[string][]structField
+	}{{
+		name: "basic",
+		schema: `{
+			"type": "record",
+			"name": "Person",
+			"fields": [
+				{"name": "first_name", "type": "string"},
+				{"name": "age", "type": "int"}
+			]
+		}`,
+		expect: map[string][]structField{
+			"Person": {{
+				GoName:  "FirstName",
+				GoType:  "string",
+				AvroTag: "first_name",
+			}, {
+				GoName:  "Age",
+				GoType:  "int32",
+				AvroTag: "age",
+			}},
+		},
+	}, {
+		name: "nested",
+		schema: `{
+			"type": "record",
+			"name": "Person",
+			"fields": [
+				{
+					"name": "address",
+					"type": {
+						"type": "record",
+						"name": "address",
+						"fields": [
+							{ "name": "suburb", "type": "string" }
+						]
+					}
+				}
+			]
+		}`,
+		expect: map[string][]structField{
+			"Address": {{
+				GoName:  "Suburb",
+				GoType:  "string",
+				AvroTag: "suburb",
+			}},
+			"Person": {{
+				GoName:  "Address",
+				GoType:  "*Address",
+				AvroTag: "address",
+			}},
+		},
+	}, {
+		name: "array",
+		schema: `{
+			"type": "record",
+			"name": "Person",
+			"fields": [{
+				"name": "nameArray",
+				"type": {
+					"type": "array",
+					"items": "string"
+				}
+			}]
+		}`,
+		expect: map[string][]structField{
+			"Person": {{
+				GoName:  "NameArray",
+				GoType:  "[]string",
+				AvroTag: "nameArray",
+			}},
+		},
+	}, {
+		name: "pointer",
+		schema: `{
+			"type": "record",
+			"name": "Person",
+			"fields": [
+				{"name": "first_name", "type": [ "null", "string" ]}
+			]
+		}`,
+		expect: map[string][]structField{
+			"Person": {{
+				GoName:  "FirstName",
+				GoType:  "string",
+				AvroTag: "first_name",
+			}},
+		},
+	}} {
+		t.Run(testCase.name, func(t *testing.T) {
+			gen := NewCodeGenerator([]string{testCase.schema})
+			generatedCode, err := gen.Generate()
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Log(generatedCode)
+
+			structs, err := extractStructTypes(generatedCode)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			for typeName, expectedFields := range testCase.expect {
+				structDef, ok := structs[typeName]
+				if !ok {
+					t.Errorf("No type %s in generated code", typeName)
+					return
+				}
+
+				for idx, expected := range expectedFields {
+					if idx >= len(structDef.Fields.List) {
+						t.Fatalf("Index %d (%s) out of range of fields", idx, expected.GoType)
+					}
+
+					field := structDef.Fields.List[idx]
+					if len(field.Names) != 1 {
+						t.Fatalf("%d name fields for %s", len(field.Names), expected.GoType)
+					}
+					if field.Names[0].Name != expected.GoName {
+						t.Errorf("Bad field name, want %s got %s", expected.GoName, field.Names[0].Name)
+					}
+
+					typeName := rebuildTypeName(field.Type)
+
+					if typeName != expected.GoType {
+						t.Errorf("Bad Type for %s: %s", expected.GoName, typeName)
+					}
+
+					// AST version includes ``, reflect does not
+					structTag := reflect.StructTag(field.Tag.Value[1 : len(field.Tag.Value)-1])
+					avroTag := structTag.Get("avro")
+					if avroTag != expected.AvroTag {
+						t.Errorf("Bad struct tag: %s (%s)", field.Tag.Value, avroTag)
+					}
+				}
+			}
+
+		})
+	}
+}
+
+func rebuildTypeName(fieldType ast.Expr) string {
+
+	if _, ok := fieldType.(*ast.InterfaceType); ok {
+		// TODO: Non empty interface?
+		return "interface{}"
+	}
+
+	if arrayExpr, ok := fieldType.(*ast.ArrayType); ok {
+		return "[]" + rebuildTypeName(arrayExpr.Elt)
+	}
+
+	if starExpr, ok := fieldType.(*ast.StarExpr); ok {
+		return "*" + rebuildTypeName(starExpr.X)
+	}
+
+	typeIdent, ok := fieldType.(*ast.Ident)
+	if !ok {
+		return "UNKNOWN TYPE"
+	}
+
+	return typeIdent.Name
+}

--- a/codegen_test.go
+++ b/codegen_test.go
@@ -121,7 +121,7 @@ func TestCodegen(t *testing.T) {
 			}},
 			"Person": {{
 				GoName:  "Address",
-				GoType:  "Address",
+				GoType:  "*Address",
 				AvroTag: "address",
 			}},
 		},


### PR DESCRIPTION
- Fix import path in generated code
- Improve go field names
- Include `avro` tags in struct fields
- Support unions of one (Probably bad practice, but exists in the wild)
- Fix a bug with types on defaults
- Adds tests